### PR TITLE
Set up dev environment + remove defunct polyfill.io scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+PULS is a single-product **Vite + React 19 SPA** (Romanian physics-education site). There is no in-repo backend; the "backend" is hosted Firebase (Auth/Firestore/Storage) consumed directly from the client, plus optional third-party APIs (n8n chat, Groq, DeepL, Cloudinary, ImageKit). See `README.md` for the full feature/route list and `package.json` for scripts.
+
+### Running / building
+- Dev server: `npm run dev` → serves at `http://localhost:8000` (port is fixed in `vite.config.js`).
+- Build: `npm run build`. Lint: `npm run lint`. There is no automated test suite.
+
+### Critical gotcha: the app needs a `.env` or it renders a blank page
+- `src/lib/firebase.js` calls `getAuth()` at module load. If `VITE_FIREBASE_*` env vars are missing/empty, Firebase throws `auth/invalid-api-key`, which crashes the whole React tree — **every** page (including static simulation pages) shows a blank white screen with only a console error.
+- A `.env` file (gitignored, so it does not persist across fresh VMs) with **non-empty, syntactically-valid** `VITE_FIREBASE_*` values is required just for the app to mount. For local demos where a live backend isn't needed, dummy values (e.g. `VITE_FIREBASE_API_KEY=AIzaSyDUMMY...`, a project id, etc.) are enough — copy `.env.example` to `.env` and fill placeholders. For real auth/Firestore data (login, problems, classes, profiles) use real Firebase credentials (add them as Cursor Secrets or in `.env`).
+- Note: Vite loads env from `.env` files, so if credentials are provided as VM env vars/Secrets you may still need them written into a `.env` for the client bundle to pick them up.
+
+### What works without external services
+- The interactive physics simulations (`public/simulari/*`, embedded via iframe on `/simulare/:slug`) are fully client-side and work once Firebase has initialized (even with dummy config). They are the best zero-credential smoke test.
+- Simulations may load an external `polyfill.io` script, which can trigger a browser HTTP-auth prompt — cancel/dismiss it; the simulation still works.
+
+### Linting note
+- `npm run lint` reports ~1250 pre-existing errors, almost all from the root-level Node maintenance scripts (`upload-*.js`, `extract-*.js`, `vite.config.js`, etc.) using `process`/`Buffer`/`__dirname` without Node globals configured in ESLint. These are pre-existing and unrelated to the app under `src/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
1. Sets up and verifies the development environment for the PULS Vite + React SPA, documenting durable setup guidance for future cloud agents in `AGENTS.md`.
2. Removes the defunct `polyfill.io` `<script>` tags from all 7 simulation HTML pages.

## Environment setup
- Update script (registered separately): `npm install`.
- `AGENTS.md` `## Cursor Cloud specific instructions`: how to run/build/lint, the critical blank-page-without-`.env` Firebase gotcha, what works without external services, and pre-existing lint noise in root maintenance scripts.

### Verification
- `npm install` — installs dependencies (Node v22, npm 10).
- `npm run lint` — runs (reports pre-existing errors in root Node scripts, unrelated to app `src/`).
- `npm run build` — production build succeeds.
- `npm run dev` — dev server serves at `http://localhost:8000`.
- Hello-world: homepage renders, `/simulari` lists simulations, and an interactive pendulum simulation animates in real time.

## polyfill.io removal
`polyfill.io` is dead (taken down after the June 2024 supply-chain compromise). It only backfilled ES6 for legacy browsers alongside MathJax v3, and its now-broken endpoint triggered a stray browser HTTP-auth popup (a latent security liability). Removed the tags from:
- `public/simulari/Unde/simulator-unde.html`
- `public/simulari/Oscilatii-ox/index.html`
- `public/simulari/Oscilatii-oy/index.html`
- `public/simulari/Mix/Reprezentari3d.html`
- `public/simulari/Mix/Pendul-amplitudine.html`
- `public/simulari/Mix/Oscilatie-amortizata.html`
- `public/simulari/prisma/prisma-simulator.html`

Verified in-browser across all 7 affected simulations: each loads, MathJax formulas still render as typeset equations, interactions work, and the login popup no longer appears.

[simulations_working_without_polyfill.mp4](https://cursor.com/agents/bc-341c815d-795c-4092-931f-ceefa91bf2c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsimulations_working_without_polyfill.mp4)

[Pendul simplu simulation working without polyfill](https://cursor.com/agents/bc-341c815d-795c-4092-931f-ceefa91bf2c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsim_pendul_simplu_no_polyfill.webp)
[Prisma simulation with Snell](https://cursor.com/agents/bc-341c815d-795c-4092-931f-ceefa91bf2c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsim_prisma_no_polyfill.webp)
[Oscilatii OX simulation working without polyfill](https://cursor.com/agents/bc-341c815d-795c-4092-931f-ceefa91bf2c1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsim_oscilatii_ox_no_polyfill.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-341c815d-795c-4092-931f-ceefa91bf2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-341c815d-795c-4092-931f-ceefa91bf2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project documentation with setup, build, and lint instructions.
  * Clarified the required environment variables needed for the app to load successfully.
  * Included guidance on what can be used without external services and noted existing lint issues outside the app code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->