### PR TITLE
Remove defunct polyfill.io script tags from simulation pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ PULS is a single-product **Vite + React 19 SPA** (Romanian physics-education sit
 
 ### What works without external services
 - The interactive physics simulations (`public/simulari/*`, embedded via iframe on `/simulare/:slug`) are fully client-side and work once Firebase has initialized (even with dummy config). They are the best zero-credential smoke test.
-- Simulations may load an external `polyfill.io` script, which can trigger a browser HTTP-auth prompt — cancel/dismiss it; the simulation still works.
+- The now-defunct `polyfill.io` `<script>` tags were removed from the simulation pages (they only backfilled ES6 for legacy browsers and triggered a stray HTTP-auth popup). MathJax formula rendering still works without them in modern browsers — do not re-add `polyfill.io`.
 
 ### Linting note
 - `npm run lint` reports ~1250 pre-existing errors, almost all from the root-level Node maintenance scripts (`upload-*.js`, `extract-*.js`, `vite.config.js`, etc.) using `process`/`Buffer`/`__dirname` without Node globals configured in ESLint. These are pre-existing and unrelated to the app under `src/`.

--- a/public/simulari/Mix/Oscilatie-amortizata.html
+++ b/public/simulari/Mix/Oscilatie-amortizata.html
@@ -89,8 +89,6 @@
 <script src="/simulari/simulator-i18n-runtime.js"></script>
 <script src="pendul-amortizat-boot.js"></script>
 <script type="text/javascript" async 
-  src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-<script type="text/javascript" async 
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
 </body>

--- a/public/simulari/Mix/Pendul-amplitudine.html
+++ b/public/simulari/Mix/Pendul-amplitudine.html
@@ -101,8 +101,6 @@
 <script src="/simulari/simulator-i18n-runtime.js"></script>
 <script src="pendul-neliniar-boot.js"></script>
 <script type="text/javascript" async 
-  src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-<script type="text/javascript" async 
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
 </body>

--- a/public/simulari/Mix/Reprezentari3d.html
+++ b/public/simulari/Mix/Reprezentari3d.html
@@ -94,8 +94,6 @@
 <script src="/simulari/simulator-i18n-runtime.js"></script>
 <script src="pendul-simplu-boot.js"></script>
 <script type="text/javascript" async 
-  src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-<script type="text/javascript" async 
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 
 </body>

--- a/public/simulari/Oscilatii-ox/index.html
+++ b/public/simulari/Oscilatii-ox/index.html
@@ -6,7 +6,6 @@
     <title>Simulator Legea lui Hooke OX</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script>
         window.MathJax = {
             tex: { inlineMath: [['\\(', '\\)']], displayMath: [['\\[', '\\]']], processEscapes: true },

--- a/public/simulari/Oscilatii-oy/index.html
+++ b/public/simulari/Oscilatii-oy/index.html
@@ -6,7 +6,6 @@
     <title>Simulator Legea lui Hooke OY</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script>
         window.MathJax = {
             tex: { inlineMath: [['\\(', '\\)']], displayMath: [['\\[', '\\]']], processEscapes: true },

--- a/public/simulari/Unde/simulator-unde.html
+++ b/public/simulari/Unde/simulator-unde.html
@@ -74,7 +74,6 @@
 
     <script src="/simulari/simulator-i18n-runtime.js"></script>
     <script src="unde-apa-boot.js"></script>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 

--- a/public/simulari/prisma/prisma-simulator.html
+++ b/public/simulari/prisma/prisma-simulator.html
@@ -37,7 +37,6 @@
 
   <script src="/simulari/simulator-i18n-runtime.js"></script>
   <script src="prisma-boot.js"></script>
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The polyfill.io domain is dead (taken down after the June 2024 supply-chain compromise) and only served to backfill ES6 for legacy browsers alongside MathJax. Its <script> tags triggered a stray browser HTTP-auth popup and are a latent security liability. Removed from all 7 simulation HTML files; verified in-browser that all simulations still load, MathJax formulas render, and interactions work in modern browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed outdated external script loading from several simulation pages, reducing the chance of unexpected browser prompts or loading issues.
  * Math rendering remains available, and some pages now use an updated math display loader for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->